### PR TITLE
BPL-466 json TaskParamsKeyType (serializable objects)

### DIFF
--- a/retry_tasks_lib/db/models.py
+++ b/retry_tasks_lib/db/models.py
@@ -1,3 +1,5 @@
+import json
+
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -45,10 +47,14 @@ class RetryTask(TmpBase, TimestampMixin):
     task_type_key_values = relationship("TaskTypeKeyValue", back_populates="retry_task", lazy="joined")
 
     def get_task_type_key_values(self, values: list[tuple[int, str]]) -> list["TaskTypeKeyValue"]:
-        return [
-            TaskTypeKeyValue(retry_task_id=self.retry_task_id, task_type_key_id=key_id, value=value)
-            for key_id, value in values
-        ]
+        task_type_key_values: list[TaskTypeKeyValue] = []
+        for key_id, value in values:
+            serialization_fn = json.dumps if isinstance(value, (dict, list)) else str
+            val = serialization_fn(value)
+            task_type_key_values.append(
+                TaskTypeKeyValue(retry_task_id=self.retry_task_id, task_type_key_id=key_id, value=val)
+            )
+        return task_type_key_values
 
     def get_params(self) -> dict:
         task_params: dict = {}

--- a/retry_tasks_lib/enums.py
+++ b/retry_tasks_lib/enums.py
@@ -1,9 +1,11 @@
+import enum
+import json
+
 from datetime import date, datetime
-from enum import Enum
 from typing import Any
 
 
-class RetryTaskStatuses(Enum):
+class RetryTaskStatuses(enum.Enum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     RETRYING = "retrying"
@@ -24,19 +26,28 @@ class RetryTaskStatuses(Enum):
         return [cls.FAILED.name, cls.CANCELLED.name]
 
 
-class TaskParamsKeyTypes(Enum):
-    STRING = str
-    INTEGER = int
-    FLOAT = float
-    BOOLEAN = bool
-    DATE = date
-    DATETIME = datetime
+class TaskParamsKeyTypes(enum.Enum):
+    STRING = enum.auto()
+    INTEGER = enum.auto()
+    FLOAT = enum.auto()
+    BOOLEAN = enum.auto()
+    DATE = enum.auto()
+    DATETIME = enum.auto()
+    JSON = enum.auto()
 
-    def convert_value(self, v: str) -> Any:
-        if self.value == bool:
-            return v.lower() in ["true", "1", "t", "yes", "y"]
-
-        if self.value in [date, datetime]:
-            return self.value.fromisoformat(v)
-
-        return self.value(v)
+    def convert_value(self, v: str) -> Any:  # pylint: disable=too-many-return-statements
+        match self:
+            case TaskParamsKeyTypes.STRING:
+                return str(v)
+            case TaskParamsKeyTypes.INTEGER:
+                return int(v)
+            case TaskParamsKeyTypes.FLOAT:
+                return float(v)
+            case TaskParamsKeyTypes.BOOLEAN:
+                return v.lower() in ["true", "1", "t", "yes", "y"]
+            case TaskParamsKeyTypes.DATE:
+                return date.fromisoformat(v)
+            case TaskParamsKeyTypes.DATETIME:
+                return datetime.fromisoformat(v)
+            case TaskParamsKeyTypes.JSON:
+                return json.loads(v)

--- a/retry_tasks_lib/utils/asynchronous.py
+++ b/retry_tasks_lib/utils/asynchronous.py
@@ -32,7 +32,7 @@ async def async_create_task(db_session: AsyncSession, *, task_type_name: str, pa
     await db_session.flush()
     key_ids_by_name = task_type.get_key_ids_by_name()
     db_session.add_all(
-        retry_task.get_task_type_key_values([(key_ids_by_name[key], str(val)) for (key, val) in params.items()])
+        retry_task.get_task_type_key_values([(key_ids_by_name[key], val) for (key, val) in params.items()])
     )
     await db_session.flush()
     return retry_task

--- a/retry_tasks_lib/utils/synchronous.py
+++ b/retry_tasks_lib/utils/synchronous.py
@@ -320,7 +320,7 @@ def sync_create_task(db_session: Session, *, task_type_name: str, params: dict[s
     key_ids_by_name = task_type.get_key_ids_by_name()
 
     db_session.bulk_save_objects(
-        retry_task.get_task_type_key_values([(key_ids_by_name[key], str(val)) for key, val in params.items()])
+        retry_task.get_task_type_key_values([(key_ids_by_name[key], val) for key, val in params.items()])
     )
 
     db_session.flush()
@@ -343,7 +343,7 @@ def sync_create_many_tasks(
     db_session.flush()
 
     for retry_task, params in zip(retry_tasks, params_list):
-        values = [(keys[k], str(v)) for k, v in params.items()]
+        values = [(keys[k], v) for k, v in params.items()]
         db_session.bulk_save_objects(retry_task.get_task_type_key_values(values))
 
     db_session.flush()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def task_type_keys() -> list[tuple[str, TaskParamsKeyTypes]]:
         ("task-type-key-bool", TaskParamsKeyTypes.BOOLEAN),
         ("task-type-key-date", TaskParamsKeyTypes.DATE),
         ("task-type-key-datetime", TaskParamsKeyTypes.DATETIME),
+        ("task-type-key-json", TaskParamsKeyTypes.JSON),
     ]
 
 

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -200,7 +200,7 @@ async def test__get_pending_retry_tasks(
 
 @pytest.mark.asyncio
 async def test_async_create_task(async_db_session: "AsyncSession", task_type_with_keys_async: TaskType) -> None:
-    params = {"task-type-key-str": "astring", "task-type-key-int": 42}
+    params = {"task-type-key-str": "astring", "task-type-key-int": 42, "task-type-key-json": ["list", "of", "stuff"]}
     retry_task = await async_create_task(
         db_session=async_db_session,
         task_type_name="task-type",

--- a/tests/test_sync_utils.py
+++ b/tests/test_sync_utils.py
@@ -1,7 +1,7 @@
 # pylint: disable=unused-argument, no-value-for-parameter
 
 from datetime import datetime, timedelta, timezone
-from typing import Generator
+from typing import Any, Generator
 from unittest import mock
 
 import pytest
@@ -351,10 +351,11 @@ def test_sync_create_task_and_get_retry_task(sync_db_session: "Session", task_ty
 def test_sync_create_many_tasks_and_get_retry_task(
     sync_db_session: "Session", task_type_with_keys_sync: TaskType
 ) -> None:
-    params_list = [
+    params_list: list[dict[str, Any]] = [
         {"task-type-key-str": "a_string", "task-type-key-int": 42},
         {"task-type-key-str": "b_string", "task-type-key-int": 43},
         {"task-type-key-str": "c_string", "task-type-key-int": 44},
+        {"task-type-key-str": "c_string", "task-type-key-json": {"x": "y"}},
     ]
     retry_tasks = sync_create_many_tasks(
         db_session=sync_db_session, task_type_name="task-type", params_list=params_list


### PR DESCRIPTION
Note: This will require a migration to add the JSON type to the `taskparamskeytypes` enumeration in any project that wishes to use the new TYPE:

```
polaris=# SELECT enum_range(NULL::taskparamskeytypes);
                  enum_range
----------------------------------------------
 {STRING,INTEGER,FLOAT,BOOLEAN,DATE,DATETIME}
(1 row)
```