### PR TITLE
Feature/bpl 273 enqueue task clean from admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ You'll need to install:
 - Then make a new Release in that project.
 - Same process as other apps - tag it on the master branch with the new version number.
 - That will make the new package and put it on the pypi server
-- Then edit the consuming app's Pipfile to the new version number and run `pipenv lock && pipenv sync --dev`
+- Then edit the consuming app's pyproject.toml to the new version number and run `poetry lock --no-update && poetry install --sync`
 
 

--- a/retry_tasks_lib/db/models.py
+++ b/retry_tasks_lib/db/models.py
@@ -102,6 +102,7 @@ class TaskType(TmpBase, TimestampMixin):
     task_type_id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False, index=True, unique=True)
     path = Column(String, nullable=False)
+    cleanup_handler_path = Column(String, nullable=True)
     error_handler_path = Column(String, nullable=False)
     queue_name = Column(String, nullable=False)
 

--- a/retry_tasks_lib/enums.py
+++ b/retry_tasks_lib/enums.py
@@ -14,11 +14,15 @@ class RetryTaskStatuses(enum.Enum):
     WAITING = "waiting"
     CANCELLED = "cancelled"
     REQUEUED = "requeued"
+    CLEANUP = "cleanup"
+    CLEANUP_FAILED = "cleanupfailed"
 
     @classmethod
     def cancellable_statuses_names(cls) -> list[str]:
         return [
-            task_status.name for task_status in cls if task_status not in [cls.SUCCESS, cls.CANCELLED, cls.REQUEUED]
+            task_status.name
+            for task_status in cls
+            if task_status not in [cls.SUCCESS, cls.CANCELLED, cls.REQUEUED, cls.IN_PROGRESS]
         ]
 
     @classmethod

--- a/retry_tasks_lib/utils/__init__.py
+++ b/retry_tasks_lib/utils/__init__.py
@@ -1,0 +1,16 @@
+from importlib import import_module
+from typing import Callable
+
+
+class UnresolvableHandlerPath(Exception):
+    pass
+
+
+def resolve_callable_from_path(path: str) -> Callable:
+    try:
+        mod, func = path.rsplit(".", 1)
+        module = import_module(name=mod)
+        handler: Callable = getattr(module, func)
+        return handler
+    except (ValueError, ModuleNotFoundError, AttributeError) as ex:
+        raise UnresolvableHandlerPath(f"Could resolve callable for path {ex}")  # pylint: disable=raise-missing-from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def mock_async_db_session() -> AsyncMock:
 
 
 @pytest.fixture(scope="function")
-def mock_sync_db_session() -> AsyncMock:
+def mock_sync_db_session() -> MagicMock:
     return MagicMock(spec=Session)
 
 
@@ -152,4 +152,42 @@ async def retry_task_async(async_db_session: "Session", task_type_with_keys_asyn
     )
     async_db_session.add(task)
     await async_db_session.commit()
+    return task
+
+
+@pytest.fixture(scope="function")
+def task_type_with_keys_and_cleanup_handler_path(
+    sync_db_session: "Session", task_type_keys: list[tuple[str, TaskParamsKeyTypes]]
+) -> TaskType:
+    task_type = TaskType(
+        name="task-type-with-cleanup",
+        path="path.to.func",
+        queue_name="queue-name",
+        error_handler_path="path.to.error_handler",
+        cleanup_handler_path="tests.conftest.mock_cleanup_hanlder_fn",
+    )
+    sync_db_session.add(task_type)
+    sync_db_session.flush()
+    task_type_keys_objs: list[TaskTypeKey] = [
+        TaskTypeKey(name=key_name, type=key_type, task_type_id=task_type.task_type_id)
+        for key_name, key_type in task_type_keys
+    ]
+    sync_db_session.add_all(task_type_keys_objs)
+    sync_db_session.commit()
+    return task_type
+
+
+@pytest.fixture(scope="function")
+def retry_task_sync_with_cleanup(
+    sync_db_session: "Session", task_type_with_keys_and_cleanup_handler_path: TaskType
+) -> RetryTask:
+    task = RetryTask(
+        task_type_id=task_type_with_keys_and_cleanup_handler_path.task_type_id,
+        status=RetryTaskStatuses.CLEANUP,
+        attempts=0,
+        audit_data=[],
+        next_attempt_time=None,
+    )
+    sync_db_session.add(task)
+    sync_db_session.commit()
     return task

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import logging
+
+from pytest_mock import MockerFixture
+
+from retry_tasks_lib.utils import resolve_callable_from_path
+
+
+def mock_callable() -> None:
+    logging.info("Running mock callable function")
+
+
+def test_resolve_callable_from_path(mocker: MockerFixture) -> None:
+    mock_logger = mocker.patch("tests.test_utils.logging.info")
+
+    path_to_mock_callable = "tests.test_utils.mock_callable"
+    callable_handler = resolve_callable_from_path(path_to_mock_callable)
+    callable_handler()
+
+    mock_logger.assert_called_once_with("Running mock callable function")


### PR DESCRIPTION
- Adds a new column to the TaskType table, the value of which can be nullable
- New @cleanup_handler decorator to be used with functions intended to run a task specific clean up job after a task is cancelled
- When a task is cancelled from the admin view, it will enqueue the job back onto rq but with the cleanup_handler_path as the function to run, with retry_task_id as the kwarg. 

See #28 for related comments